### PR TITLE
Fix undefined is not an object error in getRecentTracks

### DIFF
--- a/src/classes/user.class.ts
+++ b/src/classes/user.class.ts
@@ -220,7 +220,7 @@ export default class User extends Base {
     return {
       search: {
         user: attr.user,
-        nowPlaying: !!toBool(trackMatches[0]['@attr']?.nowplaying),
+        nowPlaying: !!toBool(trackMatches?.[0]?.['@attr']?.nowplaying),
         page: toInt(attr.page),
         itemsPerPage: toInt(attr.perPage),
         totalPages: toInt(attr.totalPages),


### PR DESCRIPTION
Getting this error:
```ts
150 |         });
151 |         return {
152 |             search: {
153 |                 user: attr.user,
154 |                 nowPlaying: trackMatches[0]['@attr']?.nowplaying === 'true',
                                  ^
TypeError: undefined is not an object (evaluating 'trackMatches[0]["@attr"]')
      at node_modules/@solely/simple-fm/dist/classes/user.class.js:154:29
```

Kind of an unlikely edge case, but if the user has no scrobbles then `trackMatches[0]` is undefined